### PR TITLE
refactor: destructure context values in Chart, Slider components

### DIFF
--- a/src/Chart.svelte
+++ b/src/Chart.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { getContext, onDestroy } from "svelte";
+  import { getContext } from "svelte";
   import { flip } from "svelte/animate";
   import type { FlipParams } from "svelte/animate";
-  import type { BarChartRaceContext, BarChartRaceOptions, BarChartRaceValuesByKey } from "./shared";
+  import type { BarChartRaceContext } from "./shared";
 
   /**
    * Customize the animation delay, duration, and easing.
@@ -10,27 +10,14 @@
    */
   export let animate: FlipParams = {};
 
-  const ctx: BarChartRaceContext = getContext("BarChartRace");
-
-  let value = -1;
-  let valuesByKey: BarChartRaceValuesByKey = {};
-  let options: BarChartRaceOptions = {};
-  let unsubValue = ctx.value.subscribe((_value) => (value = _value));
-  let unsubValuesByKey = ctx.valuesByKey.subscribe((_valuesByKey) => (valuesByKey = _valuesByKey));
-  let unsubOptions = ctx.chartOptions.subscribe((_options) => (options = _options));
-
-  onDestroy(() => {
-    unsubValue();
-    unsubValuesByKey();
-    unsubOptions();
-  });
+  const { value, valuesByKey, chartOptions }: BarChartRaceContext = getContext("BarChartRace");
 </script>
 
 <ol style:padding="var(--chart-padding, 0)">
-  {#each valuesByKey[value] as datum (datum.title)}
+  {#each $valuesByKey[$value] as datum (datum.title)}
     <li animate:flip={animate}>
       <slot {datum}>
-        {datum.title}: {datum.value}{options.unit ?? ""}
+        {datum.title}: {datum.value}{$chartOptions.unit ?? ""}
       </slot>
       <svg
         width="100%"
@@ -40,7 +27,7 @@
       >
         <rect
           height="100%"
-          width="{(datum.value / options.max) * 100}%"
+          width="{(datum.value / $chartOptions.max) * 100}%"
           fill={datum.color || "#333"}
         />
       </svg>

--- a/src/Slider.svelte
+++ b/src/Slider.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { getContext, onDestroy } from "svelte";
-  import type { BarChartRaceContext, BarChartRaceRange } from "./shared";
+  import { getContext } from "svelte";
+  import type { BarChartRaceContext } from "./shared";
 
   /** Specify a slider id. */
   export let id = "slider-" + Math.random().toString(36);
@@ -8,31 +8,21 @@
   /** Specify the slider label text. */
   export let labelText: any = "";
 
-  const ctx: BarChartRaceContext = getContext("BarChartRace");
+  const { value, range, setValue }: BarChartRaceContext = getContext("BarChartRace");
 
-  let value = -1;
-  let range: BarChartRaceRange = [];
-  let unsubValue = ctx.value.subscribe((_value) => (value = _value));
-  let unsubRange = ctx.range.subscribe((_range) => (range = _range));
-
-  $: max = range[range.length - 1];
-  $: min = range[0];
-
-  onDestroy(() => {
-    unsubValue();
-    unsubRange();
-  });
+  $: max = $range[$range.length - 1];
+  $: min = $range[0];
 </script>
 
 <input
   {...$$restProps}
   type="range"
-  bind:value
+  bind:value={$value}
   {id}
   {min}
   {max}
-  on:input={(e) => ctx.setValue(Number(e.currentTarget.value))}
+  on:input={(e) => setValue(Number(e.currentTarget.value))}
 />
-<label for={id}>{labelText + "" || value}</label>
+<label for={id}>{labelText + "" || $value}</label>
 
 <!-- @component `Slider` must be descendent of `BarChartRace`. -->


### PR DESCRIPTION
Context values can be destructured instead of manually subscribing and unsubscribing.

This saves a lot of boilerplate in regards to initializing values, importing types, and using the `onDestroy` lifecycle method.